### PR TITLE
Bump langchain-community from 0.0.27 to 0.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 art==6.1
 colorama==0.4.6
 langchain==0.1.11
-langchain_community==0.0.27
+langchain_community==0.2.9
 msal==1.25.0
 openai==1.13.3
 Pillow==10.3.0


### PR DESCRIPTION
### Description

In this pull request, the version of the package `langchain_community` in the `requirements.txt` file is being updated from `0.0.27` to `0.2.9`.

Changes:
- Update the version of `langchain_community` package in the requirements.txt file from `0.0.27` to `0.2.9`.